### PR TITLE
JSDoc for `props`

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -21,7 +21,9 @@ export const getStaticProps = async () => {
 };
 
 /**
- * @param {{newsletters: Newsletter[]}} props
+ * 
+ * @param {object} props 
+ * @param {Newsletter[]} props.newsletters
  */
 const Home = ({ newsletters }) => {
   return (


### PR DESCRIPTION
## What does this change?
This improves how JSDoc is being used to type the props for a react component. Now we can list each property on its own line.