### PR TITLE
Dblatcher/success headline depends on email confirmation

### DIFF
--- a/src/jobs/__tests__/newsletters.test.ts
+++ b/src/jobs/__tests__/newsletters.test.ts
@@ -28,8 +28,7 @@ const EXPECTED_RESULTS = [
 			),
 			description:
 				"News doesn’t have to be bad. Get a weekly shot of optimism with real solutions to the world's most pressing problems.",
-			successHeadline:
-				'Check your email inbox and confirm your subscription',
+			successHeadline: 'Subscription confirmed',
 			successDescription:
 				"Thanks for subscribing. We'll send you The Upside every week",
 			hexCode: '#DCDCDC',
@@ -45,7 +44,7 @@ const EXPECTED_RESULTS = [
 			'brazeSubscribeAttributeNameAlternate2',
 		],
 		paused: true,
-		emailConfirmation: true,
+		emailConfirmation: false,
 	},
 ];
 
@@ -55,7 +54,7 @@ const VALID_NEWSLETTER_ENTRY = [
 	'The Upside',
 	'',
 	'TRUE',
-	'TRUE',
+	'',
 	'/world/series/the-upside-weekly-report/latest/email',
 	'Series of same name',
 	'Weekly, Friday/ad usually, ~12-2pm',

--- a/src/jobs/newsletters.ts
+++ b/src/jobs/newsletters.ts
@@ -75,8 +75,9 @@ const rowToNewsletter = ({
 				mailTitle || `Sign up for ${mailName || name}`,
 			),
 			description: mailDescription ? mailDescription : description,
-			successHeadline:
-				'Check your email inbox and confirm your subscription',
+			successHeadline: emailConfirmation
+				? 'Check your email inbox and confirm your subscription'
+				: 'Subscription confirmed',
 			successDescription:
 				mailSuccessDescription || 'Thanks for subscribing!',
 			hexCode: mailHexCode || '#DCDCDC',


### PR DESCRIPTION
## What does this change?

The value of ``emailEmbed.successHeadline`` field for a newsletter response will now be "Subscription confirmed" if the ``emailConfirmation`` field of the newsletter is false. If ``emailConfirmation`` is true ``emailEmbed.successHeadline`` remains the same as before (i.e. "Check your email inbox and confirm your subscription").

This is so the message displayed to users when they sign up using an email embed or the all newsletters page will be "Subscription confirmed" if there will be no validation email to confirm the sign up. The intent is for all newsletters in production to not use validation email, so in practise, all newsletters will use "Subscription confirmed".  

## How to test

On the  CODE version of the spreadsheet, change a ``emailConfirmation``  (currently column F) to either an empty cell or 'TRUE'. The  ``emailEmbed.successHeadline`` field on the API response for the newsletter should change accordingly.




