### PR TITLE
Use boolean instead of truthy string to determine successHeadline

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.42.0",
     "@types/aws-lambda": "^8.10.85",
-    "fp-ts": "^2.11.5",
     "googleapis": "^88.2.0",
     "io-ts": "^2.2.16",
     "io-ts-extra": "^0.11.6",

--- a/src/jobs/newsletters.ts
+++ b/src/jobs/newsletters.ts
@@ -22,6 +22,9 @@ const getIllustration = (
 	return { circle };
 };
 
+const isTrue = (str: string | undefined): boolean =>
+	str !== undefined ? str.toLowerCase() === 'true' : false;
+
 const rowToNewsletter = ({
 	[THEME_INDEX]: theme,
 	[GROUP_INDEX]: group,
@@ -53,9 +56,9 @@ const rowToNewsletter = ({
 	({
 		identityName,
 		name,
-		restricted: restricted == 'TRUE',
-		paused: paused == 'TRUE',
-		emailConfirmation: emailConfirmation == 'TRUE',
+		restricted: isTrue(restricted),
+		paused: isTrue(paused),
+		emailConfirmation: isTrue(emailConfirmation),
 		brazeNewsletterName,
 		brazeSubscribeAttributeName:
 			brazeSubscribeAttributeName ||
@@ -75,7 +78,7 @@ const rowToNewsletter = ({
 				mailTitle || `Sign up for ${mailName || name}`,
 			),
 			description: mailDescription ? mailDescription : description,
-			successHeadline: emailConfirmation
+			successHeadline: isTrue(emailConfirmation)
 				? 'Check your email inbox and confirm your subscription'
 				: 'Subscription confirmed',
 			successDescription:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3745,7 +3745,7 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-fp-ts@^2.1.0, fp-ts@^2.11.5:
+fp-ts@^2.1.0:
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.11.5.tgz#97cceb26655b1452d7088d6fb0864f84cceffbe4"
   integrity sha512-OqlwJq1BdpB83BZXTqI+dNcA6uYk6qk4u9Cgnt64Y+XS7dwdbp/mobx8S2KXf2AXH+scNmA/UVK3SEFHR3vHZA==


### PR DESCRIPTION
## What does this change?

* `successHeadline` was always being set to "Check your email inbox and confirm your subscription" due to checking a truthy string instead of a boolean

## How to test

* API output should set `successHeadline` correctly based on the `emailConfirmation` flag