### PR TITLE
Set allowed deploy stages to CODE, PROD

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,5 +1,6 @@
 stacks: [frontend]
 regions: [eu-west-1]
+allowedStages: [CODE, PROD]
 
 deployments:
   cloudformation:


### PR DESCRIPTION
## What does this change?

* Sets the allowed deploy stages in Riff Raff to `CODE, PROD`