### PR TITLE
Add monitoring

### DIFF
--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -110,7 +110,7 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 4,
+        "DatapointsToAlarm": 3,
         "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {

--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -110,6 +110,7 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
         "EvaluationPeriods": 10,
         "Metrics": Array [
           Object {

--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -93,7 +93,7 @@ Object {
               Object {
                 "Ref": "newsletterssourcelambdaDC8710B7",
               },
-              " exceeded 100% error rate",
+              " exceeded 99% error rate",
             ],
           ],
         },
@@ -168,7 +168,7 @@ Object {
             "ReturnData": false,
           },
         ],
-        "Threshold": 100,
+        "Threshold": 99,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",

--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -110,8 +110,7 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 2,
-        "EvaluationPeriods": 15,
+        "EvaluationPeriods": 10,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",

--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -65,6 +65,114 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
+    "newsletterssourcelambdaErrorPercentageAlarmForLambda11C2FE6A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":newsletters-alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "newsletterssourcelambdaDC8710B7",
+              },
+              " exceeded 100% error rate",
+            ],
+          ],
+        },
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "High error % from ",
+              Object {
+                "Ref": "newsletterssourcelambdaDC8710B7",
+              },
+              " lambda in TEST",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 10,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "Error % of ",
+                  Object {
+                    "Ref": "newsletterssourcelambdaDC8710B7",
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "newsletterssourcelambdaDC8710B7",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "newsletterssourcelambdaDC8710B7",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "newsletterssourcelambdaServiceRole6F6F519E": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {

--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -110,7 +110,8 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 10,
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 7,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",

--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -110,8 +110,8 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 2,
-        "EvaluationPeriods": 10,
+        "DatapointsToAlarm": 4,
+        "EvaluationPeriods": 1,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",

--- a/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-source.test.ts.snap
@@ -110,8 +110,8 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 3,
-        "EvaluationPeriods": 1,
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 15,
         "Metrics": Array [
           Object {
             "Expression": "100*m1/m2",

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -30,8 +30,13 @@ export class NewslettersSource extends GuStack {
 			handler: 'cron.handler',
 			fileName: `${app}.zip`,
 			monitoringConfiguration: {
+				/*
+				The alarm will trigger if:
+					* > 99% of requests are failing
+					* there are at least 3 failing runs (datapointsToAlarm)
+				*/
 				toleratedErrorPercentage: 99,
-				datapointsToAlarm: 4,
+				datapointsToAlarm: 3,
 				snsTopicName: `newsletters-alerts`,
 			},
 			rules: [{ schedule: Schedule.rate(Duration.minutes(5)) }],

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -31,9 +31,7 @@ export class NewslettersSource extends GuStack {
 			fileName: `${app}.zip`,
 			monitoringConfiguration: {
 				/*
-				The alarm will trigger if:
-					* > 99% of requests are failing
-					* the error condition still exists after 10 minutes
+				The alarm will trigger if: >= 2 runs fail within 7 minutes
 				*/
 				toleratedErrorPercentage: 99,
 				numberOfMinutesAboveThresholdBeforeAlarm: 7,

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -31,8 +31,7 @@ export class NewslettersSource extends GuStack {
 			fileName: `${app}.zip`,
 			monitoringConfiguration: {
 				toleratedErrorPercentage: 99,
-				datapointsToAlarm: 2,
-				numberOfMinutesAboveThresholdBeforeAlarm: 10,
+				datapointsToAlarm: 4,
 				snsTopicName: `newsletters-alerts`,
 			},
 			rules: [{ schedule: Schedule.rate(Duration.minutes(5)) }],

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -33,12 +33,10 @@ export class NewslettersSource extends GuStack {
 				/*
 				The alarm will trigger if:
 					* > 99% of requests are failing
-					* there are at least 2 failing runs (datapointsToAlarm)
-					* the error condition still exists after 15 minutes
+					* the error condition still exists after 10 minutes
 				*/
 				toleratedErrorPercentage: 99,
-				datapointsToAlarm: 2,
-				numberOfMinutesAboveThresholdBeforeAlarm: 15,
+				numberOfMinutesAboveThresholdBeforeAlarm: 10,
 				snsTopicName: `newsletters-alerts`,
 			},
 			rules: [{ schedule: Schedule.rate(Duration.minutes(5)) }],

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -33,10 +33,12 @@ export class NewslettersSource extends GuStack {
 				/*
 				The alarm will trigger if:
 					* > 99% of requests are failing
-					* there are at least 3 failing runs (datapointsToAlarm)
+					* there are at least 2 failing runs (datapointsToAlarm)
+					* the error condition still exists after 15 minutes
 				*/
 				toleratedErrorPercentage: 99,
-				datapointsToAlarm: 3,
+				datapointsToAlarm: 2,
+				numberOfMinutesAboveThresholdBeforeAlarm: 15,
 				snsTopicName: `newsletters-alerts`,
 			},
 			rules: [{ schedule: Schedule.rate(Duration.minutes(5)) }],

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -31,6 +31,7 @@ export class NewslettersSource extends GuStack {
 			fileName: `${app}.zip`,
 			monitoringConfiguration: {
 				toleratedErrorPercentage: 99,
+				datapointsToAlarm: 2,
 				numberOfMinutesAboveThresholdBeforeAlarm: 10,
 				snsTopicName: `newsletters-alerts`,
 			},

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -30,7 +30,7 @@ export class NewslettersSource extends GuStack {
 			handler: 'cron.handler',
 			fileName: `${app}.zip`,
 			monitoringConfiguration: {
-				toleratedErrorPercentage: 100,
+				toleratedErrorPercentage: 99,
 				numberOfMinutesAboveThresholdBeforeAlarm: 10,
 				snsTopicName: `newsletters-alerts`,
 			},

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -36,7 +36,8 @@ export class NewslettersSource extends GuStack {
 					* the error condition still exists after 10 minutes
 				*/
 				toleratedErrorPercentage: 99,
-				numberOfMinutesAboveThresholdBeforeAlarm: 10,
+				numberOfMinutesAboveThresholdBeforeAlarm: 7,
+				datapointsToAlarm: 2,
 				snsTopicName: `newsletters-alerts`,
 			},
 			rules: [{ schedule: Schedule.rate(Duration.minutes(5)) }],

--- a/cdk/lib/newsletters-source.ts
+++ b/cdk/lib/newsletters-source.ts
@@ -29,7 +29,11 @@ export class NewslettersSource extends GuStack {
 			memorySize: 512,
 			handler: 'cron.handler',
 			fileName: `${app}.zip`,
-			monitoringConfiguration: { noMonitoring: true },
+			monitoringConfiguration: {
+				toleratedErrorPercentage: 100,
+				numberOfMinutesAboveThresholdBeforeAlarm: 10,
+				snsTopicName: `newsletters-alerts`,
+			},
 			rules: [{ schedule: Schedule.rate(Duration.minutes(5)) }],
 			timeout: Duration.seconds(60),
 			environment: {

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,19 +1,13 @@
-import { ALBResult, ScheduledEvent } from 'aws-lambda';
 import { buildNewsletters } from './jobs/jobs';
 
-const handler = async (event?: ScheduledEvent): Promise<ALBResult> => {
-	console.log(`Event ${JSON.stringify(event)}`);
-	const result = await buildNewsletters();
-	console.log(`Job result ${JSON.stringify(result)}`);
-	return result;
-};
-
-const runLocal = async (): Promise<void> => {
-	await handler();
+const handler = async (): Promise<void> => {
+	console.log(`Running job`);
+	await buildNewsletters();
+	console.log(`Job completed`);
 };
 
 if (process.env.STAGE === 'DEVELOPMENT') {
-	runLocal();
+	handler();
 }
 
 exports.handler = handler;

--- a/src/jobs/jobs.ts
+++ b/src/jobs/jobs.ts
@@ -1,9 +1,8 @@
-import { ALBResult } from 'aws-lambda';
 import { NEWSLETTERS_BUCKET_NAME } from '../constants';
 import { s3upload } from '../lib/s3Upload';
 import { getEmailNewsletters } from './newsletters';
 
-const buildNewsletters = async (): Promise<ALBResult> => {
+const buildNewsletters = async (): Promise<void> => {
 	try {
 		console.log(`Getting newsletters from Google sheet`);
 		const newsletters = await getEmailNewsletters();
@@ -15,15 +14,10 @@ const buildNewsletters = async (): Promise<ALBResult> => {
 			Body: JSON.stringify(newsletters),
 		});
 		console.log(`Uploaded to S3`);
-		return {
-			body: `${newsletters.length} newsletters successfully processed`,
-			statusCode: 200,
-		};
+		console.log(`${newsletters.length} newsletters successfully processed`);
 	} catch (e) {
-		return {
-			body: (e as Error).message,
-			statusCode: 500,
-		};
+		console.error((e as Error).message);
+		throw e;
 	}
 };
 


### PR DESCRIPTION
## What does this change?

* Refactors the event handler to throw an error if one is encountered
  * This results in a failed execution which will trigger the monitoring alarm
* Removes `ALBResult` as we are not using Application Load Balancer
  * replaced with `void`, as there is no useful return type from this application
* Adds monitoring configuration
  * triggers an alarm if there are two failed runs within 7 minutes
  * as the service runs on a 5-minute cron, we need to trigger the alarm after only a small number of datapoints. there is a risk of this alarm being too sensitive - we should review it if so
  * publishes to the `newsletters-alerts` SNS channel

## How to test

* Try to trigger an alarm and verify the event ends up in the SNS queue
