### PR TITLE
Add the @guardian/newsletters team as codeowners of this repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@guardian/newsletters


### PR DESCRIPTION
## What does this change?

Adds the [`@guardian/newsletters`](https://github.com/orgs/guardian/teams/newsletters) team as codeowners of this repository