### PR TITLE
Removed unnecessary bucket parameter

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -16,6 +16,5 @@ deployments:
     type: aws-lambda
     dependencies: [cloudformation]
     parameters:
-      bucket: com-gu-frontend-artifacts
       fileName: newsletters-source.zip
       functionNames: [-newsletters-source-]


### PR DESCRIPTION
Co-authored-by: @akash1810
Co-authored-by: @ioannakok 

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Removes the parameter pointing to the `com-gu-frontend-artifacts` bucket on the back of the [silently failing deployments issue](https://docs.google.com/document/d/1xNtvBELOISYXyosLO0yKrl3GEQx61lrUvoRbY_Hgedk/edit#task=xiEEaN136gGMsEMK). After [this change](https://github.com/guardian/aws-account-setup/pull/51), this project will deploy to the correct value by default.  

In terms of the application, there should be no noticeable impact to what's running. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Performing a deploy should continue to be successful. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
